### PR TITLE
Fix PSR-4 Autoloading syntax for Composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"minimum-stability": "stable",
 	"autoload": {
 		"psr-4": {
-			"Litipk\\Exceptions": "src/"
+			"Litipk\\Exceptions\\": "src/"
 		}
 	}
 }


### PR DESCRIPTION
This fixes a syntax error (Invalid Argument Exception) when trying to create an autoloader from Composer.

>Namespace prefixes must end in \\ to avoid conflicts between similar prefixes. For example Foo would match classes in the FooBar namespace so the trailing backslashes solve the problem: Foo\\ and FooBar\\ are distinct.

https://getcomposer.org/doc/04-schema.md#psr-4